### PR TITLE
1: Fixed Black Lights

### DIFF
--- a/Solitude/Assets/Materials/Sci-Fi Pack/Light/Flood/Flood_Light_off.mat
+++ b/Solitude/Assets/Materials/Sci-Fi Pack/Light/Flood/Flood_Light_off.mat
@@ -42,7 +42,7 @@ Material:
     - first:
         name: _EmissionMap
       second:
-        m_Texture: {fileID: 2800000, guid: 418fc4e0fdbe8f34c8226f219ee77d1c, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - first:

--- a/Solitude/Assets/PreFabs/Multi/Lights/FloodLightOn.prefab
+++ b/Solitude/Assets/PreFabs/Multi/Lights/FloodLightOn.prefab
@@ -62,7 +62,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 4294967295
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!1 &1837884448006304
 GameObject:
   m_ObjectHideFlags: 0
@@ -293,6 +293,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 319da692e82c1e34aa8eb8601faca7d5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  power: 0
   lightOn: {fileID: 1636515948048416}
   lightOff: {fileID: 1690686663172774}

--- a/Solitude/Assets/Standard Assets/Objects Materials and Textures.meta
+++ b/Solitude/Assets/Standard Assets/Objects Materials and Textures.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: f51588eabe2cbf446ad944b1b59e3e64
-folderAsset: yes
-timeCreated: 1496153388
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Solitude/Assets/Standard Assets/objects.meta
+++ b/Solitude/Assets/Standard Assets/objects.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: e31eab0ba226613499bc9ab25d98f0df
-folderAsset: yes
-timeCreated: 1496153388
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
The off light was disabled for light baking and thus appeared pitch
black because it had no light bounces compared to the reset of the scene
objects.
FloodLightOn.prefab
changed both child objects to be active.